### PR TITLE
ED-391

### DIFF
--- a/common/djangoapps/external_auth/backends.py
+++ b/common/djangoapps/external_auth/backends.py
@@ -133,7 +133,7 @@ class CASBackend(object):
         try:
             user = User.objects.get(email=username)
         except User.DoesNotExist:
-            u_name = username.split('@')[0]
+            u_name = username
             user = User(username=u_name, email=username)
             user.set_unusable_password()
 

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -58,6 +58,8 @@ from util.model_utils import emit_field_changed_events, get_changed_fields_dict
 from util.query import use_read_replica_if_available
 from util.milestones_helpers import is_entrance_exams_enabled
 
+from openedx.core.djangoapps.content.course_overviews.connector import EdevateDbConnector
+
 
 UNENROLL_DONE = Signal(providing_args=["course_enrollment", "skip_refund"])
 log = logging.getLogger(__name__)
@@ -1260,6 +1262,11 @@ class CourseEnrollment(models.Model):
         if badges_enabled():
             from lms.djangoapps.badges.events.course_meta import award_enrollment_badge
             award_enrollment_badge(user)
+
+        # update edevate CourseUser
+        edevate_db = EdevateDbConnector()
+        edevate_db.update_users_course_list(course_key, user.email)
+        edevate_db.close()
 
         return enrollment
 

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -127,7 +127,6 @@ from eventtracking import tracker
 from notification_prefs.views import enable_notifications
 
 # Note that this lives in openedx, so this dependency should be refactored.
-from openedx.core.djangoapps.content.course_overviews.connector import EdevateDbConnector
 from openedx.core.djangoapps.credentials.utils import get_user_program_credentials
 from openedx.core.djangoapps.credit.email_utils import get_credit_provider_display_names, make_providers_strings
 from openedx.core.djangoapps.user_api.preferences import api as preferences_api
@@ -986,12 +985,6 @@ def _credit_statuses(user, course_enrollments):
     return statuses
 
 
-def edevate_update_user_course_list(user, course_id):
-    edevate_db = EdevateDbConnector()
-    edevate_db.update_users_course_list(course_id, user.email)
-    edevate_db.close()
-
-
 @transaction.non_atomic_requests
 @require_POST
 @outer_atomic(read_committed=True)
@@ -1078,7 +1071,6 @@ def change_enrollment(request, check_access=True):
 
         if user.subscriber.is_active_subscription:
             CourseEnrollment.enroll(user, course_id, check_access=False, mode='honor')
-            edevate_update_user_course_list(user, course_id)
             return HttpResponse()
 
         # Check that auto enrollment is allowed for this course
@@ -1094,7 +1086,6 @@ def change_enrollment(request, check_access=True):
                 enroll_mode = CourseMode.auto_enroll_mode(course_id, available_modes)
                 if enroll_mode:
                     CourseEnrollment.enroll(user, course_id, check_access=check_access, mode=enroll_mode)
-                    edevate_update_user_course_list(user, course_id)
             except Exception:  # pylint: disable=broad-except
                 return HttpResponseBadRequest(_("Could not enroll"))
 

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1084,9 +1084,11 @@ def change_enrollment(request, check_access=True):
             # to "audit".
             try:
                 enroll_mode = CourseMode.auto_enroll_mode(course_id, available_modes)
+                print enroll_mode
                 if enroll_mode:
                     CourseEnrollment.enroll(user, course_id, check_access=check_access, mode=enroll_mode)
-            except Exception:  # pylint: disable=broad-except
+            except Exception as e:  # pylint: disable=broad-except
+                print e
                 return HttpResponseBadRequest(_("Could not enroll"))
 
         # If we have more than one course mode or professional ed is enabled,

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1084,11 +1084,9 @@ def change_enrollment(request, check_access=True):
             # to "audit".
             try:
                 enroll_mode = CourseMode.auto_enroll_mode(course_id, available_modes)
-                print enroll_mode
                 if enroll_mode:
                     CourseEnrollment.enroll(user, course_id, check_access=check_access, mode=enroll_mode)
             except Exception as e:  # pylint: disable=broad-except
-                print e
                 return HttpResponseBadRequest(_("Could not enroll"))
 
         # If we have more than one course mode or professional ed is enabled,

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1086,7 +1086,7 @@ def change_enrollment(request, check_access=True):
                 enroll_mode = CourseMode.auto_enroll_mode(course_id, available_modes)
                 if enroll_mode:
                     CourseEnrollment.enroll(user, course_id, check_access=check_access, mode=enroll_mode)
-            except Exception as e:  # pylint: disable=broad-except
+            except Exception:  # pylint: disable=broad-except
                 return HttpResponseBadRequest(_("Could not enroll"))
 
         # If we have more than one course mode or professional ed is enabled,

--- a/openedx/core/djangoapps/content/course_overviews/connector.py
+++ b/openedx/core/djangoapps/content/course_overviews/connector.py
@@ -32,7 +32,7 @@ class EdevateDbConnector:
             self.connection.close()
 
     def get_edevate_user_id(self, user_email):
-        self.cursor.execute("""SELECT *
+        self.cursor.execute("""SELECT id
                                FROM users_customuser
                                WHERE email='{}';""".format(user_email)
                             )
@@ -104,25 +104,20 @@ class EdevateDbConnector:
         logger.debug("Get edevate course_ptr_id: {!r}".format(course_ptr_id))
         return course_ptr_id[0]
 
-    def check_user_course(self, course_ptr_id):
+    def course_user_exists(self, course_ptr_id, student_id):
         self.cursor.execute("""SELECT id
                                FROM courses_courseuser
-                               WHERE course_ptr_id = '{}';
-                               """.format(course_ptr_id)
-                            )
-        course = self.cursor.fetchone()
-        if course:
-            return False
-        else:
-            return True
+                               WHERE course_ptr_id = '{}'
+                                 AND student_id = '{}';
+                               """.format(course_ptr_id))
+        return self.cursor.fetchone()
 
     def update_users_course_list(self, openedx_course_id, user):
-        edevate_user = self.get_edevate_user_id(user)
+        student_id = self.get_edevate_user_id(user)
         course_ptr_id = self.get_course(openedx_course_id)
-        if self.check_user_course(course_ptr_id):
+        if not self.course_user_exists(course_ptr_id, student_id):
             self.cursor.execute("""INSERT INTO courses_courseuser
                                    (state, removed, course_ptr_id, student_id)
                                    VALUES ('undergoing', '0', '{}', '{}');
-                                """.format(course_ptr_id, edevate_user)
-                                )
+                                """.format(course_ptr_id, student_id))
             self.connection.commit()

--- a/openedx/core/djangoapps/content/course_overviews/connector.py
+++ b/openedx/core/djangoapps/content/course_overviews/connector.py
@@ -98,8 +98,7 @@ class EdevateDbConnector:
         self.cursor.execute("""SELECT id
                                FROM courses_course
                                WHERE url LIKE '%{}%';
-                               """.format(openedx_course_id)
-                            )
+                            """.format(openedx_course_id))
         course_ptr_id = self.cursor.fetchone()
         logger.debug("Get edevate course_ptr_id: {!r}".format(course_ptr_id))
         return course_ptr_id[0]
@@ -109,7 +108,7 @@ class EdevateDbConnector:
                                FROM courses_courseuser
                                WHERE course_ptr_id = '{}'
                                  AND student_id = '{}';
-                               """.format(course_ptr_id))
+                            """.format(course_ptr_id, student_id))
         return self.cursor.fetchone()
 
     def update_users_course_list(self, openedx_course_id, user):


### PR DESCRIPTION
- move updating edevate db to `CourseEnrollment.enroll` to fire it for all cases when user enrolls
- minor fix for sql code
- a bit unrelevant change - don't use email.split('@')[0] for username to allow `john@mail.com` and `john@microhard.com` to register at the same time (username column is unique in openedx User model)
